### PR TITLE
Remove updated on from jinja template

### DIFF
--- a/templates/reference_item_template.jinja
+++ b/templates/reference_item_template.jinja
@@ -73,5 +73,4 @@
     {% endif %}
 </table>
 
-Updated on {{ today }}.
 {% endblock %}


### PR DESCRIPTION
Regenerating docs was creating big messy commits even for simple changes due to 470+ trivial one-line changes in timestamps across the files. Dropping the Updated On line makes it easier to track actual changes in the documentation.